### PR TITLE
Add highscore feature

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -261,6 +261,7 @@ async def on_message(message):
                 current_highscore = get_highscore(message.channel.id)
 
                 if current_count <= current_highscore:
+                    await message.channel.send(f"```Current highscore: {current_highscore}. Try to beat it!```")
                     return
                 await message.channel.send(f"```New highscore: {current_count}!```")
                 update_highscore(message.channel.id, current_count)
@@ -320,6 +321,29 @@ async def delete_channel(ctx, channel: discord.TextChannel):
             await ctx.reply(f'```Channel {channel.name} removed!```')
     finally:
         close_connection(conn)
+
+
+# Command to show the highscore
+@bot.command(description='Show the highscore of the current channel.')
+async def highscore(ctx):
+    if not await is_channel_allowed(ctx.message):
+        await ctx.reply("```This channel is not activated for counting.```")
+        return
+
+    current_highscore = get_highscore(ctx.channel.id)
+    await ctx.reply(f'```Current highscore: {current_highscore}```')
+
+
+# Command to reset the highscore
+@bot.command(description='Reset the highscore of the current channel.')
+@commands.has_permissions(administrator=True)
+async def reset_highscore(ctx):
+    if not await is_channel_allowed(ctx.message):
+        await ctx.reply("```This channel is not activated for counting.```")
+        return
+
+    update_highscore(ctx.channel.id, 0)
+    await ctx.reply("```Highscore reset.```")
 
 
 # Set counter

--- a/bot.py
+++ b/bot.py
@@ -82,20 +82,31 @@ def setup_database():
         ''')
         connection.commit()
         logger.info("Database table created successfully.")
+
+        # Check if all columns exist
+        cursor.execute("PRAGMA table_info(channels)")
+        columns = [column[1] for column in cursor.fetchall()]
+        required_columns = ["channel_id", "count", "last_user_id", "highscore"]
+        for column in required_columns:
+            logger.info(f"Checking for column {column}")
+            if column not in columns:
+                cursor.execute(f"ALTER TABLE channels ADD COLUMN {column}")
+                connection.commit()
+                logger.info(f"Column {column} added successfully.")
     except sqlite3.Error as e:
-        logger.error(f"Failed to create table: {e}")
+        logger.error(f"Failed to create or alter table: {e}")
     finally:
         close_connection(connection)
 
 
 def update_count(channel_id, new_count, user_id):
+    logger.info(f"{channel_id} requests: update count to {new_count} for user {user_id}")
     """Update the count in the database for a given channel."""
     conn = create_connection()
-    sql = ''' REPLACE INTO channels(channel_id, count, last_user_id)
-              VALUES(?,?,?) '''
+    sql = ''' UPDATE channels SET count = ?, last_user_id = ? WHERE channel_id = ? '''
     try:
         cur = conn.cursor()
-        cur.execute(sql, (channel_id, new_count, user_id))
+        cur.execute(sql, (new_count, user_id, channel_id))
         conn.commit()
     except sqlite3.Error as e:
         print(e)
@@ -103,7 +114,43 @@ def update_count(channel_id, new_count, user_id):
         close_connection(conn)
 
 
+def get_highscore(channel_id):
+    logger.info(f"{channel_id} requests: get highscore")
+    """Retrieve the highscore for a given channel from the database."""
+    conn = create_connection()
+    sql = ''' SELECT highscore FROM channels WHERE channel_id = ? '''
+    try:
+        cur = conn.cursor()
+        cur.execute(sql, (channel_id,))
+        row = cur.fetchone()
+        if row:
+            return row[0]
+    except sqlite3.Error as e:
+        print(e)
+    finally:
+        close_connection(conn)
+    return 0  # Default to 0 if not found
+
+
+def update_highscore(channel_id, new_highscore):
+    logger.info(f"{channel_id} requests: update highscore to {new_highscore}")
+    conn = create_connection()
+
+    """Update the highscore in the database for a given channel."""
+    sql = ''' UPDATE channels SET highscore = ? WHERE channel_id = ? '''
+    try:
+        cur = conn.cursor()
+        cur.execute(sql, (new_highscore, channel_id))
+        conn.commit()
+    except sqlite3.Error as e:
+        logger.error(f"Failed to update highscore: {e}")
+        print(e)
+    finally:
+        close_connection(conn)
+
+
 def get_current_count(channel_id):
+    logger.info(f"{channel_id} requests: get current count")
     """Retrieve the current count and last user ID for a given channel from the database."""
     conn = create_connection()
     sql = ''' SELECT count, last_user_id FROM channels WHERE channel_id = ? '''
@@ -210,6 +257,13 @@ async def on_message(message):
                     await message.add_reaction(NEGATIVE_EMOJI)
                     await message.reply(f"```The Number should be {current_count + 1}. Starting from 1 again.```")
 
+                """Check if current highscore is less than new highscore and update it."""
+                current_highscore = get_highscore(message.channel.id)
+
+                if current_count <= current_highscore:
+                    return
+                await message.channel.send(f"```New highscore: {current_count}!```")
+                update_highscore(message.channel.id, current_count)
         except ValueError:
             pass  # Ignore messages that are not numbers
 


### PR DESCRIPTION
- Introduces the ability to save a highscore upon a counting failure, preserving the channel's highest achievement.
- Automatically displays the current highscore when a user fails to count correctly, providing immediate feedback and motivation.
- Adds a command to manually retrieve and display the channel's highscore, fostering a competitive environment.
- Implements an administrative command to reset the highscore, allowing for controlled management and reinitiation of counting challenges.